### PR TITLE
Allow the user to specify an ENV to set the install.sh location override

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
       # This action installs Chef Omnibus packages at the desired version.
       class InstallChef
 
-        INSTALL_SH = "https://www.opscode.com/chef/install.sh".freeze
+        INSTALL_SH = "#{ENV['OMNIBUS_INSTALL_URL'] || 'https://www.opscode.com/chef/install.sh'}"
 
         def initialize(app, env)
           @app = app


### PR DESCRIPTION
This one fixes #9 - 

Tested and looks like it's working

```
~/repos/omnibus-chef/vagrant/freebsd (master ✔)  ᐅ OMNIBUS_INSTALL_URL="http://dyn-vm.s3.amazonaws.com/chef/install.sh" vagrant provision
[default] Ensuring Chef is installed at requested version of 11.4.0.
[default] Chef 11.4.0 Omnibus package is not installed...installing now.
* About to connect() to dyn-vm.s3.amazonaws.com port 80 (#0)
*   Trying 205.251.242.184...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* connected
```
