### PR TITLE
add support for vmware_fusion

### DIFF
--- a/lib/vagrant-omnibus/plugin.rb
+++ b/lib/vagrant-omnibus/plugin.rb
@@ -47,7 +47,7 @@ module VagrantPlugins
         # fire after anything boot related which wedges in right before the
         # actual real run of the provisioner.
 
-        if HashiCorp.const_defined?("VagrantVMwarefusion")
+        if defined?(HashiCorp) && HashiCorp.const_defined?("VagrantVMwarefusion")
           hook.after(HashiCorp::VagrantVMwarefusion::Action::Boot, Action.install_chef)
         end
         


### PR DESCRIPTION
Added support in the workaround for VMware Fusion provider.

Couldn't work out how to add tests for vagrant-vmware-fusion as it would not run for me in a `bundle` environment.
