### PR TITLE
Add support for the Digital Ocean provider.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 group :test do
   gem "vagrant-aws", "~> 0.2.2"
   gem "vagrant-rackspace", "~> 0.1.1"
+  gem "vagrant-digitalocean", "~> 0.2.0"
 end
 
 group :docs do

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,10 @@ namespace :test do
       unless system("vagrant box list | grep 'dummy\s*(#{provider})' &>/dev/null")
         system("vagrant box add dummy https://github.com/mitchellh/vagrant-#{provider}/raw/master/dummy.box")
       end
+
+      unless system("vagrant box list | grep 'digital_ocean' &>/dev/null")
+        sytem("vagrant box add digital_ocean https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box")
+      end
     end
 
     all_providers = Dir["test/acceptance/*"].map{|dir| File.basename(File.expand_path(dir))}

--- a/lib/vagrant-omnibus/plugin.rb
+++ b/lib/vagrant-omnibus/plugin.rb
@@ -68,8 +68,7 @@ module VagrantPlugins
         # END workaround
       end
 
-      action_hook(:install_chef, :machine_action_up, &method(:provision))
-      action_hook(:install_chef, :machine_action_provision, &method(:provision))
+      action_hook(:install_chef, Plugin::ALL_ACTIONS, &method(:provision))
 
       config(:omnibus) do
         require_relative "config"

--- a/test/acceptance/digital_ocean/Vagrantfile
+++ b/test/acceptance/digital_ocean/Vagrantfile
@@ -1,0 +1,23 @@
+Vagrant.require_plugin('vagrant-omnibus')
+Vagrant.require_plugin('vagrant-digitalocean')
+
+Vagrant.configure('2') do |config|
+  config.omnibus.chef_version = '11.4.0'
+
+  config.vm.box = 'digital_ocean'
+  config.vm.synced_folder '.', '/vagrant', :disabled => true
+
+  config.vm.provider :digital_ocean do |provider, override|
+    provider.client_id = ENV['DO_CLIENT_ID']
+    provider.api_key = ENV['DO_API_KEY']
+    provider.region = 'New York 1'
+    provider.size = '512MB'
+    provider.image = 'Ubuntu 12.04 x64 Server'
+    override.ssh.private_key_path = '~/.ssh/id_rsa'
+  end
+
+  config.vm.provision :chef_solo do |chef|
+    chef.cookbooks_path = File.expand_path("../../../support/cookbooks", __FILE__)
+    chef.add_recipe "chef-inator"
+  end
+end


### PR DESCRIPTION
This commit modifies how the Chef installation hook is registered.
Rather than specify each action hook (up, provision), it hooks into
all potential actions that run the Vagrant provision middleware. This
enables custom commands that run provisioning to ensure that Chef is
installed. The Digital Ocean provider has a custom command, rebuild,
that requires this modification.

Additionally, an acceptance test for Digital Ocean has been provided and
sucessfully run. Acceptance tests for the other providers with this
modification have not been tested since the author does not have
accounts for those cloud services.
