### PR TITLE
no need to do sudo in sudo

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -65,9 +65,9 @@ module VagrantPlugins
         def install(version)
           command = <<-INSTALL_OMNIBUS
             if command -v wget &>/dev/null; then
-              wget -qO- #{INSTALL_SH} | sudo bash -s -- -v #{version}
+              wget -qO- #{INSTALL_SH} | bash -s -- -v #{version}
             elif command -v curl &>/dev/null; then
-              curl -L #{INSTALL_SH} -v #{version} | sudo bash
+              curl -L #{INSTALL_SH} -v #{version} | bash
             else
               echo "Neither wget nor curl found. Please install one." >&2
               exit 1


### PR DESCRIPTION
I got an error as follows when I did vagrant up --provider=virtualbox with centos 6.3_x86 minimal box.

[web_test] Installing Chef 11.6.0 Omnibus package...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

```
        if command -v wget &>/dev/null; then
          wget -qO- https://www.opscode.com/chef/install.sh | sudo bash -s -- -v 11.6.0
        elif command -v curl &>/dev/null; then
          curl -L https://www.opscode.com/chef/install.sh -v 11.6.0 | sudo bash
        else
          echo "Neither wget nor curl found. Please install one." >&2
          exit 1
        fi
```

Stdout from the command:

Stderr from the command:

vagrant is not in the sudoers file.  This incident will be reported.

This is because not root but only vagrant is in /etc/sudoers.
The easiest way to avoid this issue is not to do nested sudo as root cannot sudo.
