### PR TITLE
Fix the curl line to install the requested Chef version

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -67,7 +67,7 @@ module VagrantPlugins
             if command -v wget &>/dev/null; then
               wget -qO- #{INSTALL_SH} | bash -s -- -v #{version}
             elif command -v curl &>/dev/null; then
-              curl -L #{INSTALL_SH} -v #{version} | bash
+              curl -L #{INSTALL_SH} | bash -s -- -v #{version}
             else
               echo "Neither wget nor curl found. Please install one." >&2
               exit 1


### PR DESCRIPTION
If the box didn't have wget installed, the curl version always installed the latest version of Chef client.

This PR is built on top of #31.
