### PR TITLE
Hook before the `Provision` to get control later in the middleware stack

### DIFF
--- a/lib/vagrant-omnibus/plugin.rb
+++ b/lib/vagrant-omnibus/plugin.rb
@@ -32,7 +32,8 @@ module VagrantPlugins
 
       action_hook(:install_chef, Plugin::ALL_ACTIONS) do |hook|
         require_relative "action"
-        hook.after(Vagrant::Action::Builtin::Provision, Action.install_chef)
+
+        hook.before(Vagrant::Action::Builtin::Provision, Action.install_chef)
 
         # The AWS provider uses a non-standard Provision action on initial
         # creation:
@@ -40,7 +41,7 @@ module VagrantPlugins
         # https://github.com/mitchellh/vagrant-aws/blob/master/lib/vagrant-aws/action.rb#L105
         #
         if VagrantPlugins.const_defined?("AWS")
-          hook.after(VagrantPlugins::AWS::Action::TimedProvision, Action.install_chef)
+          hook.before(VagrantPlugins::AWS::Action::TimedProvision, Action.install_chef)
         end
       end
 


### PR DESCRIPTION
To allow [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf) plugin to configure environment for us, we hook before instead of after the `Provision` actions. This way we get back the control [in our action class](https://github.com/schisamo/vagrant-omnibus/blob/v1.1.0/lib/vagrant-omnibus/action/install_chef.rb#L35) later.

This helps tmatilai/vagrant-proxyconf#13.
