### PR TITLE
Make download of install.sh work without curl or wget (using python)

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -71,6 +71,9 @@ module VagrantPlugins
               wget -qO- #{INSTALL_SH} | bash -s -- -v #{shell_escaped_version}
             elif command -v curl &>/dev/null; then
               curl -L #{INSTALL_SH} | bash -s -- -v #{shell_escaped_version}
+            elif command -v python &>/dev/null; then
+              python -c "import sys,urllib2 ; sys.stdout.write(urllib2.urlopen('#{INSTALL_SH}').read())" \ 
+              | bash -s -- -v #{shell_escaped_version}
             else
               echo "Neither wget nor curl found. Please install one." >&2
               exit 1


### PR DESCRIPTION
Proposed workaround for #39.
This solution to #39 takes another approach: Rather than installing curl with "apt-get" or a pre-install command, we are adding next to curl and wget a download using python interpreter. We could also do it with perl, this way we will cover I think most of distributions.

Just to note, I encountered the "curl or wget is missing in the box" issue with boxes at http://cloud-images.ubuntu.com/vagrant/raring/ , that are kind of ubuntu "official" images.

Also, this workaround will probably then call https://www.opscode.com/chef/install.sh , which also only works with curl and wget. If we are ok with this python solution, we will need to propagate this changes to the install.sh.
