### PR TITLE
Fix development dependencies and Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+bundler_args: --without=acceptance
 rvm:
   - 1.9.3
 script: rake test:unit

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => "v1.2.7"
 end
 
-group :test do
+group :acceptance do
   gem "vagrant-digitalocean", "~> 0.3.0"
   gem "vagrant-aws", "~> 0.3.0"
   gem "vagrant-rackspace", "= 0.1.2"


### PR DESCRIPTION
vagrant-rackspace v0.1.3 has a conflicting fog dependency with vagrant-aws v0.3.0, so lock it down to 0.1.2 for now. This should fix the [Travis build](https://travis-ci.org/schisamo/vagrant-omnibus/builds/11586774).

Also skip installing the provided plugins at all in Travis as they are only used in acceptance tests.
