### PR TITLE
Don't install Chef if `--no-provision` is specified

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -40,7 +40,7 @@ module VagrantPlugins
         def call(env)
           @app.call(env)
 
-          return unless @machine.communicate.ready?
+          return if !@machine.communicate.ready? || !provision_enabled?(env)
 
           desired_version = @machine.config.omnibus.chef_version
           unless desired_version.nil?
@@ -60,6 +60,10 @@ module VagrantPlugins
         end
 
         private
+
+        def provision_enabled?(env)
+          env.fetch(:provision_enabled, true)
+        end
 
         def installed_version
           version = nil


### PR DESCRIPTION
Fixes #5 and #40.

Note that currently `env[:provision_enabled]` is only set when the user explicitly passes `--[no]-provision` option to `vagrant up/reload`. So with Vagrant 1.3 and later we still run our action on some cases when Vagrant won't run the provisioners. (This will change if mitchellh/vagrant#2424 is merged.)
