### PR TITLE
Change plugin name to correspond gem name

### DIFF
--- a/lib/vagrant-omnibus/plugin.rb
+++ b/lib/vagrant-omnibus/plugin.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
   module Omnibus
     # @author Seth Chisamore <schisamo@opscode.com>
     class Plugin < Vagrant.plugin("2")
-      name "Omnibus"
+      name "vagrant-omnibus"
       description <<-DESC
       This plugin ensures the desired version of Chef is installed
       via the platform-specific Omnibus packages.


### PR DESCRIPTION
Use the same name so that `Vagrant.has_plugin?` can be used with same argument as `vagrant plugin install`.

Fixes #47
