### PR TITLE
Fix installed version check to be more robust

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -73,9 +73,10 @@ module VagrantPlugins
 
         def installed_version
           version = nil
-          command = 'echo $(chef-solo --v | awk "{print \\$2}" || "")'
+          command = 'echo $(chef-solo -v)'
           @machine.communicate.sudo(command) do |type, data|
-            version = data.chomp if [:stderr, :stdout].include?(type)
+            v = data.chomp if [:stderr, :stdout].include?(type)
+            version ||= v.split()[1] if not v.empty?
           end
           version
         end


### PR DESCRIPTION
Current implementation does not correctly get a version of the installed Chef
on some platforms, such as CentOS 5.

Problem is that sudo result contains the blank line at the last,
and version is overwritten by the blank.
