### PR TITLE
filder 'stdin is not a tty' when trying to figure installed Chef version

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -78,8 +78,11 @@ module VagrantPlugins
           version = nil
           command = 'echo $(chef-solo -v)'
           @machine.communicate.sudo(command) do |type, data|
-            v = data.chomp if [:stderr, :stdout].include?(type)
-            version ||= v.split[1] unless v.empty?
+            if [:stderr, :stdout].include?(type)
+              next if data =~ /stdin: is not a tty/
+              v = data.chomp
+              version ||= v.split[1] unless v.empty?
+            end
           end
           version
         end


### PR DESCRIPTION
Hi,

We're running into an issue where `vagrant-omnibus` install chef-client on `vagrant up` even though the box :shipit: 's already, with latest `vagrant-omnibus v1.2.0`.

The script used to create the Vagrant box:

```
# Install Chef omnibus style
CHEF_VERSION=11.6.0
curl -L https://www.opscode.com/chef/install.sh | sudo bash -s -- -v $CHEF_VERSION
```

Testing the Chef version in the VM, as vagrant user:

```
irb(main):004:0> `echo $(chef-solo -v)`.chomp.split[1]
=> "11.6.0"
```

Testing with vagrant:

```
$> vagrant ssh zs1 -c 'echo $(chef-solo -v)'

Chef: 11.6.0
```

Vagrantfile config:

```
config.omnibus.chef_version = '11.6.0'
```

Output from `vagrant up` + with fresh install of the plugin:

```
$> vagrant plugin install vagrant-omnibus                                                                                                                                            
Installing the 'vagrant-omnibus' plugin. This can take a few minutes...
Installed the plugin 'vagrant-omnibus (1.2.0)'!


$> vagrant up zs1                                                                          
Bringing machine 'zs1' up with 'virtualbox' provider...
[zs1] Importing base box 'ubuntu-12.04-audax-chef-11.6.0'...
[zs1] Matching MAC address for NAT networking...
[zs1] Setting the name of the VM...
[zs1] Clearing any previously set forwarded ports...
[zs1] Clearing any previously set network interfaces...
[zs1] Preparing network interfaces based on configuration...
[zs1] Forwarding ports...
[zs1] -- 22 => 2222 (adapter 1)
[zs1] Running 'pre-boot' VM customizations...
[zs1] Booting VM...
[zs1] Waiting for machine to boot. This may take a few minutes...
[zs1] Machine booted and ready!
[zs1] Setting hostname...
[zs1] Configuring and enabling network interfaces...
[zs1] Mounting shared folders...
[zs1] -- /vagrant
[zs1] -- /tmp/vagrant-cache
[zs1] Installing Chef 11.6.0 Omnibus package...    <= (shrug)
[zs1] Downloading Chef 11.6.0 for ubuntu...
[zs1] downloading https://www.opscode.com/chef/metadata?v=11.6.0&prerelease=false&p=ubuntu&pv=12.04&m=x86_64
[zs1]   to file /tmp/install.sh.1690/metadata.txt
[zs1] trying wget...
[zs1] url   https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef_11.6.0-1.ubuntu.12.04_amd64.deb
md5 24ae91539b1093eac0438b30db7d0bfb
sha256  1f7360b9cf3af4f5704f5f672c620d480b2776c4d24771ba4d4b590e388baea0
[zs1] downloaded metadata file looks valid...
[zs1] downloading https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef_11.6.0-1.ubuntu.12.04_amd64.deb
[zs1]   to file /tmp/install.sh.1690/chef_11.6.0_amd64.deb
[zs1] trying wget...
[zs1] Checksum compare with sha256sum succeeded.
[zs1] Installing Chef 11.6.0
[zs1] installing with dpkg...
[zs1] (Reading database ...
[zs1] 68319 files and directories currently installed.)
[zs1] Preparing to replace chef 11.6.0-1.ubuntu.12.04 (using .../chef_11.6.0_amd64.deb) ...
[zs1] Unpacking replacement chef ...
[zs1] Setting up chef (11.6.0-1.ubuntu.12.04) ...
[zs1] Thank you for installing Chef!
[zs1] Running provisioner: chef_client...
```

As you can see `vagrant-omnibus` doesn't detect the Chef version correctly. The issue is related to capturing `:stdout` instead of discarding `:stderr` if matching `stdin: is not a tty`.

Building the PR:

```
$> vagrant plugin uninstall vagrant-omnibus ; vagrant plugin install /Users/scalp/audax/vagrant-omnibus/pkg/vagrant-omnibus-1.2.0.dev.gem

Installing the '/Users/scalp/audax/vagrant-omnibus/pkg/vagrant-omnibus-1.2.0.dev.gem --version '1.2.0'' plugin. This can take a few minutes...
Installed the plugin 'vagrant-omnibus (1.2.0)'!
```

`vagrant up` with Chef already installed:

```
$> vagrant up zs1
Bringing machine 'zs1' up with 'virtualbox' provider...
[zs1] Importing base box 'ubuntu-12.04-audax-chef-11.6.0'...
[zs1] Matching MAC address for NAT networking...
[zs1] Setting the name of the VM...
[zs1] Clearing any previously set forwarded ports...
[zs1] Clearing any previously set network interfaces...
[zs1] Preparing network interfaces based on configuration...
[zs1] Forwarding ports...
[zs1] -- 22 => 2222 (adapter 1)
[zs1] Running 'pre-boot' VM customizations...
[zs1] Booting VM...
[zs1] Waiting for machine to boot. This may take a few minutes...
[zs1] Machine booted and ready!
[zs1] Setting hostname...
[zs1] Configuring and enabling network interfaces...
[zs1] Mounting shared folders...
[zs1] -- /vagrant
[zs1] -- /tmp/vagrant-cache
[zs1] Chef 11.6.0 Omnibus package is already installed.  <= (success)
[zs1] Running provisioner: chef_client...
Creating folder to hold client key...
Uploading chef client validation key...
Generating chef JSON and uploading...
Running chef-client...
```

Thanks for looking into it!
