### PR TITLE
Make detection of currently installed Chef version more robust

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -100,9 +100,8 @@ module VagrantPlugins
           end
           @machine.communicate.sudo(command, opts) do |type, data|
             if [:stderr, :stdout].include?(type)
-              next if data =~ /stdin: is not a tty/
-              v = data.chomp
-              version ||= v.split[1] unless v.empty?
+              version_match = data.match(/^Chef: (.+)/)
+              version = version_match.captures[0].strip if version_match
             end
           end
           version


### PR DESCRIPTION
In some situations the result of running 'chef-solo -v' using
@machine.communicate.sudo includes more than just the command output
(eg: command prompts, session setup commands).

This change finds the chef version in the resultant output using a
regular expression to handle situations like this.
