### PR TITLE
Fixes Vagrant 1.4.* acceptance tests issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
 end
 
 group :acceptance do
-  gem 'vagrant-digitalocean', '~> 0.4.0'
+  gem 'vagrant-digitalocean', '~> 0.5.0'
   gem 'vagrant-aws', '~> 0.4.0'
   gem 'vagrant-rackspace', '~> 0.1.4'
 end


### PR DESCRIPTION
See https://github.com/smdahlen/vagrant-digitalocean/issues/92#issuecomment-35732763 for details

Basically, you can't run the acceptance tests on Vagrant > 1.3.5 without using the latest version of the vagrant-digitalocean plugin
