### PR TITLE
make unlinking the install.sh reliably work on windows hosts

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -198,11 +198,12 @@ module VagrantPlugins
             # on Windows hosts as well, see:
             # http://alx.github.io/2009/01/27/ruby-wundows-unlink.html
             file_deleted = false
-            while !file_deleted
+            until file_deleted
               begin
                 File.unlink(@script_tmp_path)
                 file_deleted = true
-              rescue
+              rescue Errno::EACCES
+                @logger.debug("failed to unlink #{@script_tmp_path}. retry...")
               end
             end
           end


### PR DESCRIPTION
On my windows box I'm regularly getting `Errno::EACCES` Permission denied errors when the downloaded `install.sh` is being unlinked in [`#recover(env)`](https://github.com/schisamo/vagrant-omnibus/blob/master/lib/vagrant-omnibus/action/install_chef.rb#L195-L199), which results in the VM being immediately destroyed afterwards.

Log snippet:

```
...
[fake_managed_server] downloading https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/13.04/x86_64/chef_11.10.4-1.ubuntu.13.04_amd64.deb
[fake_managed_server]   to file /tmp/install.sh.1109/chef_11.10.4-1.ubuntu.13.04_amd64.deb
[fake_managed_server] trying wget...
[fake_managed_server] Checksum compare with sha256sum succeeded.
[fake_managed_server] Installing Chef 11.10.4
[fake_managed_server] installing with dpkg...
[fake_managed_server] Selecting previously unselected package chef.
[fake_managed_server] (Reading database ...
[fake_managed_server] 58970 files and directories currently installed.)
[fake_managed_server] Unpacking chef (from .../chef_11.10.4-1.ubuntu.13.04_amd64.deb) ...
[fake_managed_server] Setting up chef (11.10.4-1.ubuntu.13.04) ...
[fake_managed_server] Thank you for installing Chef!
[fake_managed_server] Forcing shutdown of VM...
[fake_managed_server] Destroying VM and associated drives...
X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/gems/vagrant-omnibus-1.3.0/lib/vagrant-omnibus/action/install_chef.rb:197:in `unlink': Permission denied - X:/home/.vagrant.d/tmp/1393303058-install.sh (Errno::EACCES)
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/gems/vagrant-omnibus-1.3.0/lib/vagrant-omnibus/action/install_chef.rb:197:in `recover'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/gems/vagrant-omnibus-1.3.0/lib/vagrant-omnibus/action/install_chef.rb:59:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-berkshelf-28941db7c2f7/lib/berkshelf/vagrant/action/upload.rb:25:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-berkshelf-28941db7c2f7/lib/berkshelf/vagrant/action/install.rb:36:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/builtin/provision.rb:52:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/gems/vagrant-cachier-0.5.1/lib/vagrant-cachier/provision_ext.rb:29:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/clear_forwarded_ports.rb:13:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/plugins/providers/virtualbox/action/set_name.rb:48:in `call'
        from X:/tools/vagrant/vagrant/vagrant/embedded/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/warden.rb:34:in `call'
...
```

It seems to be a windows only problem, and I guess it's due to the fact how the [`Vagrant::Util::Downloader`](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/util/downloader.rb) is implemented. It looks like the file is not getting closed fast enough causing the `File.unlink()` to fail on windows platforms, see here:
http://www.ruby-doc.org/stdlib-1.9.3/libdoc/tempfile/rdoc/Tempfile.html#method-i-unlink-label-Unlink-before-close 

I have tried several approaches, but this was the only one which reliably worked and in fact deletes the file:
http://alx.github.io/2009/01/27/ruby-wundows-unlink.html
