### PR TITLE
run install.sh with `sh` rather than `bash`...

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -121,9 +121,8 @@ module VagrantPlugins
             if windows_guest?
               install_cmd = "cmd.exe /c #{install_script_name} #{version}"
             else
-              # TODO: Execute with `sh` once install.sh removes it's bash-isms.
               install_cmd =
-                "bash #{install_script_name} -v #{shell_escaped_version} 2>&1"
+                "sh #{install_script_name} -v #{shell_escaped_version} 2>&1"
             end
             comm.sudo(install_cmd) do |type, data|
               if [:stderr, :stdout].include?(type)


### PR DESCRIPTION
...since bash-isms seem to be removed in latest install.sh

Latest https://www.opscode.com/chef/install.sh from 25/02/2013 says:

```
#!/bin/sh
# WARNING: REQUIRES /bin/sh
#
# - must run on /bin/sh on solaris 9
# - must run on /bin/sh on AIX 6.x
# - if you think you are a bash wizard, you probably do not understand
#   this programming language.  do not touch.
# - if you are under 40, get peer review from your elders.
#
...
```
