### PR TITLE
Fix not specified chef version without internet connection

### DIFF
--- a/lib/vagrant-omnibus/config.rb
+++ b/lib/vagrant-omnibus/config.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
         finalize!
         errors = []
 
-        unless valid_chef_version?(chef_version)
+        if !chef_version.nil? && !valid_chef_version?(chef_version)
           msg = <<-EOH
 '#{ chef_version }' is not a valid version of Chef.
 

--- a/test/unit/vagrant-omnibus/config_spec.rb
+++ b/test/unit/vagrant-omnibus/config_spec.rb
@@ -65,6 +65,13 @@ describe VagrantPlugins::Omnibus::Config do
         end
       end
     end # describe chef_version
-  end # describe #validate
 
+    describe 'not specified chef_version validation' do
+      it 'passes' do
+        Gem::DependencyInstaller.any_instance.stub(:find_gems_with_sources).and_return([])
+        expect { subject.validate!(machine) }.to_not raise_error
+      end
+    end # describe not specified chef_version validation
+
+  end # describe #validate
 end


### PR DESCRIPTION
Without internet connection I can't start my vm without specified omnibus.chef_version. I've got an error: 
`'' is not a valid version of Chef.`
