### PR TITLE
Allow for caching the omnibus download by passing -d option to install.sh

### DIFF
--- a/lib/vagrant-omnibus/action/install_chef.rb
+++ b/lib/vagrant-omnibus/action/install_chef.rb
@@ -129,7 +129,7 @@ module VagrantPlugins
             else
               install_cmd = "sh #{install_script_name}"
               install_cmd << " -v #{shell_escaped_version}"
-              if omnibus_download_dir
+              unless omnibus_download_dir.nil? || omnibus_download_dir.empty?
                 install_cmd << " -d #{omnibus_download_dir}"
               end
               install_cmd << ' 2>&1'


### PR DESCRIPTION
This PR allows you to control the download directory of the omnibus package via the `-d` option of the `install.sh` (see related PR opscode/opscode-omnitruck#33) via the `OMNIBUS_DOWNLOAD_DIR` env var.

If not specified the install.sh is called without the `-d` option, i.e. the package is downloaded to a temp directory.

If  `OMNIBUS_DOWNLOAD_DIR` is specified it will be passed to install.sh, which effectively allows for caching the downloaded omnibus package (will be reused if exists and checksum matches rather than being downloaded again).  
