### PR TITLE
Fix installation docs for new Vagrant versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,15 @@ known to work with the following
 Ensure you have downloaded and installed Vagrant 1.1 or newer from the
 [Vagrant downloads page](http://downloads.vagrantup.com/).
 
-Installation is performed in the prescribed manner for Vagrant 1.1 plugins.
+For Vagrant 1.5 or newer, run:
 
+```console
+$ vagrant plugin install omnibus
 ```
+
+For older versions of Vagrant, you will need to prepend `vagrant-`.
+
+```console
 $ vagrant plugin install vagrant-omnibus
 ```
 


### PR DESCRIPTION
Old installation command fails on newer Vagrant versions, including 1.5.1 and 1.6.2.

``` console
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.9.2
BuildVersion:   13C1021
$ ruby -v
ruby 2.1.1p76 (2014-02-24 revision 45161) [x86_64-darwin12.0]
$ gem -v
2.2.2
```

``` console
$ vagrant -v
Vagrant 1.5.1
$ vagrant plugin install vagrant-ombnibus
Installing the 'vagrant-ombnibus' plugin. This can take a few minutes...
The plugin 'vagrant-ombnibus' could not be installed because it could not
be found. Please double check the name and try again.
```

``` console
$ vagrant -v
Vagrant 1.6.2
$ vagrant plugin install vagrant-ombnibus
Installing the 'vagrant-ombnibus' plugin. This can take a few minutes...
The plugin 'vagrant-ombnibus' could not be installed because it could not
be found. Please double check the name and try again.
```
