### PR TITLE
README: added info about Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ known to work with the following
 ## Installation
 
 Ensure you have downloaded and installed Vagrant 1.1 or newer from the
-[Vagrant downloads page](http://downloads.vagrantup.com/).
+[Vagrant downloads page](http://downloads.vagrantup.com/). If you require
+Windows support then Vagrant 1.6.1 or newer is needed.
 
 Installation is performed in the prescribed manner for Vagrant 1.1 plugins.
 


### PR DESCRIPTION
With Vagrant 1.6.1 (or newer) we work with Windows!

Closes #83
